### PR TITLE
Encountered nulls in route_location.crs_code field

### DIFF
--- a/src/database/MySQLSchema.ts
+++ b/src/database/MySQLSchema.ts
@@ -51,8 +51,8 @@ export class MySQLSchema {
   }
 
   private static getFieldType(field: Field): string {
-    if (field instanceof VariableLengthText) return `VARCHAR(${field.length})`;
-    if (field instanceof TextField)          return `CHAR(${field.length})`;
+    if (field instanceof VariableLengthText) return `VARCHAR(${field.length}) CHARACTER SET latin1 COLLATE latin1_general_cs`;
+    if (field instanceof TextField)          return `CHAR(${field.length}) CHARACTER SET latin1 COLLATE latin1_general_cs`;
     if (field instanceof BooleanField)       return `TINYINT(1) unsigned`;
     if (field instanceof ShortDateField)     return `DATE`;
     if (field instanceof DateField)          return `DATE`;


### PR DESCRIPTION
Line 625 of RJFAF499.RTE:
`RL009892711201670 M510   E`

Hopefully there aren't any knock on effects of having this column nullable. Should these entries just be rejected instead?
(location excluded is 'Dun Laoighaire' [Ireland] for routecode 00980 'HLYHD IRISHF CIV'; presumably this is an alternate destination that they want to disallow when using Rail+Sail)