### PR TITLE
Fix duplicate key error on restriction_header_key and others

### DIFF
--- a/src/database/MySQLSchema.ts
+++ b/src/database/MySQLSchema.ts
@@ -51,8 +51,8 @@ export class MySQLSchema {
   }
 
   private static getFieldType(field: Field): string {
-    if (field instanceof VariableLengthText) return `VARCHAR(${field.length})`;
-    if (field instanceof TextField)          return `CHAR(${field.length})`;
+    if (field instanceof VariableLengthText) return `VARCHAR(${field.length}) CHARACTER SET latin1 COLLATE latin1_general_cs`;
+    if (field instanceof TextField)          return `CHAR(${field.length}) CHARACTER SET latin1 COLLATE latin1_general_cs`;
     if (field instanceof BooleanField)       return `TINYINT(1) unsigned`;
     if (field instanceof ShortDateField)     return `DATE`;
     if (field instanceof DateField)          return `DATE`;

--- a/test/database/MySQLSchema.spec.ts
+++ b/test/database/MySQLSchema.spec.ts
@@ -41,7 +41,7 @@ describe("MySQLSchema", () => {
     schema.createSchema();
 
     chai.expect(db.queries[0]).is.equal(
-      "CREATE TABLE IF NOT EXISTS `test` (id INT(11) unsigned auto_increment NOT NULL PRIMARY KEY,`field` SMALLINT(4) unsigned NOT NULL,`field2` SMALLINT(3) unsigned zerofill NOT NULL,`field3` CHAR(5) NOT NULL,`field4` VARCHAR(5) NOT NULL,`field5` DATE NOT NULL,`field6` TIME NOT NULL,`field7` TINYINT(1) unsigned NOT NULL,`field8` DOUBLE(7, 5) unsigned NOT NULL, UNIQUE test_key (field,field4), KEY field5 (field5), KEY field6 (field6)) Engine=InnoDB"
+      "CREATE TABLE IF NOT EXISTS `test` (id INT(11) unsigned auto_increment NOT NULL PRIMARY KEY,`field` SMALLINT(4) unsigned NOT NULL,`field2` SMALLINT(3) unsigned zerofill NOT NULL,`field3` CHAR(5) CHARACTER SET latin1 COLLATE latin1_general_cs NOT NULL,`field4` VARCHAR(5) CHARACTER SET latin1 COLLATE latin1_general_cs NOT NULL,`field5` DATE NOT NULL,`field6` TIME NOT NULL,`field7` TINYINT(1) unsigned NOT NULL,`field8` DOUBLE(7, 5) unsigned NOT NULL, UNIQUE test_key (field,field4), KEY field5 (field5), KEY field6 (field6)) Engine=InnoDB"
     );
   });
 


### PR DESCRIPTION
 - Encountered on mariadb, maybe it only happens there?
 - Was getting "Error: Duplicate entry 'C-5h' for key 'restriction_header_key'" even though there was no duplicate key in RST file (restriction_header/RH subtable)
 - turns out there is a 'C-5H' (note the uppercase 'H') entry and mariadb/mysql is case insensitive in terms of collations. Ugh.