### PR TITLE
Corrected command helper for Database host name.

### DIFF
--- a/src/cli/ShowHelpCommand.ts
+++ b/src/cli/ShowHelpCommand.ts
@@ -30,7 +30,7 @@ The following environment properties are expected to be set:
   DATABASE_USERNAME          mysql username (defaults to root)
   DATABASE_PASSWORD          mysql password (defaults to none)
   DATABASE_NAME              mysql database name
-  DATABASE_HOST              mysql database host (defaults to localhost)
+  DATABASE_HOSTNAME          mysql database host (defaults to localhost)
   
 The --get-* and --download-* commands require SFTP environment properties:
 


### PR DESCRIPTION
It took me a while to figure out that it's the command help tells me to set `DATABASE_HOST` in order to connect to a remote mysql database. It's actually named `DATABASE_HOSTNAME`. Hope it can help other people save some time.